### PR TITLE
Align website brand with platform design system

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
+  /* Note: webkit requires additional system deps (libevent, libavif) - run on CI only */
   projects: [
     {
       name: 'chromium',
@@ -37,10 +38,14 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    ...(process.env.CI
+      ? [
+          {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+          },
+        ]
+      : []),
 
     /* Test against mobile viewports. */
     // {

--- a/src/components/CTDSection.astro
+++ b/src/components/CTDSection.astro
@@ -4,48 +4,72 @@ const features = [
     title: 'Capture',
     description: 'Stack traces, load order, game version. Everything a mod creator needs to debug.',
     icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+    color: 'red' as const,
   },
   {
     title: 'Share',
     description: 'One link. Send it to the mod creator. No more "what mods do you have installed?"',
     icon: 'M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z',
+    color: 'yellow' as const,
   },
   {
     title: 'Pattern',
     description: 'Same crash across users? CTD identifies it. Mod creators see what breaks.',
     icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+    color: 'green' as const,
   },
 ];
+
+const colorClasses = {
+  red: {
+    border: 'border-ez-red-700',
+    bg: 'bg-ez-red-700/10',
+    icon: 'text-ez-red-500',
+    hover: 'hover:border-ez-red-600 hover:bg-ez-red-700/20',
+  },
+  yellow: {
+    border: 'border-ez-yellow-500',
+    bg: 'bg-ez-yellow-500/10',
+    icon: 'text-ez-yellow-500',
+    hover: 'hover:border-ez-yellow-400 hover:bg-ez-yellow-500/20',
+  },
+  green: {
+    border: 'border-ez-green-500',
+    bg: 'bg-ez-green-500/10',
+    icon: 'text-ez-green-500',
+    hover: 'hover:border-ez-green-400 hover:bg-ez-green-500/20',
+  },
+};
 ---
 
 <section id="ctd" class="relative bg-ez-grey-900 py-24 lg:py-32">
-	<!-- Diagonal accent -->
-	<div class="absolute left-0 top-0 h-1 w-full bg-gradient-to-r from-ez-yellow-500 via-ez-red-700 to-transparent"></div>
+	<!-- Diagonal accent - red primary -->
+	<div class="absolute left-0 top-0 h-1 w-full bg-linear-to-r from-ez-red-700 via-ez-yellow-500 to-transparent"></div>
 
 	<div class="mx-auto max-w-7xl px-6 lg:px-8">
 		<!-- Section header -->
 		<div class="mb-16 grid gap-8 lg:mb-24 lg:grid-cols-2 lg:gap-16">
 			<div>
-				<div class="mb-4 inline-flex items-center gap-2 border border-ez-grey-700 bg-ez-grey-800 px-3 py-1">
+				<div class="mb-4 inline-flex items-center gap-2 border-2 border-ez-green-500 bg-ez-green-500/20 px-4 py-2">
 					<span class="relative flex h-2 w-2">
 						<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-ez-green-500 opacity-75"></span>
 						<span class="relative inline-flex h-2 w-2 rounded-full bg-ez-green-500"></span>
 					</span>
-					<span class="font-mono text-xs uppercase tracking-wider text-ez-grey-300">Now Live</span>
+					<span class="font-ui text-xs uppercase tracking-wider text-ez-green-500">Now Live</span>
 				</div>
 
-				<h2 class="font-display text-4xl font-bold uppercase leading-none tracking-tight text-white sm:text-5xl lg:text-6xl">
+				<h2 class="font-display text-4xl font-bold uppercase leading-[0.9] tracking-tight text-white sm:text-5xl lg:text-6xl">
 					CTD<br />
-					<span class="text-ez-yellow-500">Crash Reporter</span>
+					<span class="bg-linear-to-r from-ez-yellow-500 to-ez-red-700 bg-clip-text text-transparent">Crash Reporter</span>
 				</h2>
 			</div>
 
 			<div class="flex flex-col justify-end">
-				<p class="font-mono text-base leading-relaxed text-ez-grey-400 sm:text-lg">
+				<p class="border-l-4 border-ez-grey-500 pl-6 font-mono text-base leading-relaxed text-ez-grey-100 sm:text-lg">
 					When your game crashes, CTD captures the context. Stack trace, load order, game version.
 					Share it with mod creators so they can actually help.
 				</p>
-				<p class="mt-4 font-mono text-sm text-ez-grey-500">
+				<p class="mt-4 pl-6 font-mono text-sm text-ez-grey-500">
 					No more "can you send your load order?" No more guessing.
 				</p>
 			</div>
@@ -53,36 +77,48 @@ const features = [
 
 		<!-- Features grid -->
 		<div class="mb-16 grid gap-6 sm:grid-cols-3 lg:mb-24">
-			{features.map((feature, index) => (
-				<div class="group relative border border-ez-grey-800 bg-ez-grey-900 p-6 transition-all duration-300 hover:border-ez-yellow-500/50 hover:bg-ez-grey-800/50 sm:p-8">
-					<!-- Index number -->
-					<div class="absolute right-4 top-4 font-display text-6xl font-bold text-ez-grey-800 transition-colors group-hover:text-ez-grey-700">
-						{String(index + 1).padStart(2, '0')}
-					</div>
-
-					<div class="relative">
-						<div class="mb-4 inline-flex h-12 w-12 items-center justify-center border border-ez-yellow-500/30 bg-ez-yellow-500/10">
-							<svg class="h-6 w-6 text-ez-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-								<path stroke-linecap="round" stroke-linejoin="round" d={feature.icon} />
-							</svg>
+			{features.map((feature, index) => {
+				const colors = colorClasses[feature.color];
+				return (
+					<div class:list={[
+						'group relative border-4 p-6 transition-all duration-300 sm:p-8',
+						colors.border,
+						colors.bg,
+						colors.hover,
+					]}>
+						<!-- Index number -->
+						<div class="absolute right-4 top-4 font-display text-6xl font-bold text-ez-grey-800 transition-colors group-hover:text-ez-grey-700">
+							{String(index + 1).padStart(2, '0')}
 						</div>
 
-						<h3 class="mb-3 font-ui text-xl font-bold uppercase tracking-wide text-white">
-							{feature.title}
-						</h3>
+						<div class="relative">
+							<div class:list={[
+								'mb-4 inline-flex h-12 w-12 items-center justify-center border-2',
+								colors.border,
+								colors.bg,
+							]}>
+								<svg class:list={['h-6 w-6', colors.icon]} fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+									<path stroke-linecap="round" stroke-linejoin="round" d={feature.icon} />
+								</svg>
+							</div>
 
-						<p class="font-mono text-sm leading-relaxed text-ez-grey-400">
-							{feature.description}
-						</p>
+							<h3 class="mb-3 font-ui text-xl font-bold uppercase tracking-wide text-white">
+								{feature.title}
+							</h3>
+
+							<p class="font-mono text-sm leading-relaxed text-ez-grey-400">
+								{feature.description}
+							</p>
+						</div>
 					</div>
-				</div>
-			))}
+				);
+			})}
 		</div>
 
 		<!-- CTA Block -->
-		<div class="relative overflow-hidden border border-ez-grey-800 bg-ez-grey-950">
+		<div class="relative overflow-hidden border-4 border-ez-grey-800 bg-ez-grey-950">
 			<!-- Background pattern -->
-			<div class="absolute inset-0 opacity-5" style="background-image: url(&quot;data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23fe9a00' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E&quot;);"></div>
+			<div class="absolute inset-0 opacity-5" style="background-image: url(&quot;data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23900202' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E&quot;);"></div>
 
 			<div class="relative grid gap-8 p-8 lg:grid-cols-2 lg:gap-16 lg:p-12">
 				<div>
@@ -90,22 +126,22 @@ const features = [
 						Open Source.<br />
 						<span class="text-ez-grey-500">AGPL-3.0.</span>
 					</h3>
-					<p class="font-mono text-sm leading-relaxed text-ez-grey-400">
+					<p class="border-l-4 border-ez-grey-600 pl-4 font-mono text-sm leading-relaxed text-ez-grey-400">
 						Full source code available. Run the exact same code we do.
 						Self-host for your community. Free for modders, not for leeches.
 					</p>
 
 					<div class="mt-6 flex flex-wrap gap-3">
-						<span class="inline-flex items-center gap-1 border border-ez-grey-700 bg-ez-grey-800 px-2 py-1 font-mono text-xs text-ez-grey-400">
-							<svg class="h-3 w-3 text-ez-yellow-600" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>
+						<span class="inline-flex items-center gap-1 border-2 border-ez-grey-700 bg-ez-grey-800 px-3 py-1 font-mono text-xs text-ez-grey-400">
+							<svg class="h-3 w-3 text-ez-red-600" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>
 							rust
 						</span>
-						<span class="inline-flex items-center gap-1 border border-ez-grey-700 bg-ez-grey-800 px-2 py-1 font-mono text-xs text-ez-grey-400">
+						<span class="inline-flex items-center gap-1 border-2 border-ez-grey-700 bg-ez-grey-800 px-3 py-1 font-mono text-xs text-ez-grey-400">
 							<svg class="h-3 w-3 text-ez-yellow-600" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>
 							typescript
 						</span>
-						<span class="inline-flex items-center gap-1 border border-ez-grey-700 bg-ez-grey-800 px-2 py-1 font-mono text-xs text-ez-grey-400">
-							<svg class="h-3 w-3 text-ez-yellow-600" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>
+						<span class="inline-flex items-center gap-1 border-2 border-ez-grey-700 bg-ez-grey-800 px-3 py-1 font-mono text-xs text-ez-grey-400">
+							<svg class="h-3 w-3 text-ez-green-600" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>
 							hono
 						</span>
 					</div>
@@ -114,24 +150,20 @@ const features = [
 				<div class="flex flex-col justify-center gap-4">
 					<a
 						href="https://ctd.ezmode.games"
-						class="group relative inline-flex items-center justify-center overflow-hidden border-2 border-ez-yellow-500 bg-ez-yellow-500 px-8 py-4 font-ui text-lg font-bold uppercase tracking-wider text-ez-grey-950 transition-all hover:bg-transparent hover:text-ez-yellow-500"
+						class="group flex items-center justify-center gap-3 border-4 border-ez-yellow-500 bg-ez-yellow-500 px-8 py-5 font-ui text-lg font-bold uppercase tracking-wider text-ez-grey-950 transition-all hover:bg-transparent hover:text-ez-yellow-500"
 					>
-						<span class="relative z-10 flex items-center gap-3">
-							Try CTD
-							<svg class="h-5 w-5 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-								<path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
-							</svg>
-						</span>
+						Try CTD
+						<svg class="h-5 w-5 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+						</svg>
 					</a>
 
 					<a
 						href="https://github.com/ezmode-games/ctd"
-						class="group inline-flex items-center justify-center border-2 border-ez-grey-700 bg-transparent px-8 py-4 font-ui text-lg font-bold uppercase tracking-wider text-ez-grey-300 transition-all hover:border-ez-grey-500 hover:text-white"
+						class="group flex items-center justify-center gap-3 border-4 border-ez-red-700 bg-transparent px-8 py-5 font-ui text-lg font-bold uppercase tracking-wider text-ez-red-500 transition-all hover:bg-ez-red-700 hover:text-white"
 					>
-						<span class="flex items-center gap-3">
-							<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
-							View Source
-						</span>
+						<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+						View Source
 					</a>
 				</div>
 			</div>
@@ -139,15 +171,53 @@ const features = [
 
 		<!-- Supported games teaser -->
 		<div class="mt-16 text-center">
-			<p class="mb-6 font-mono text-sm uppercase tracking-wider text-ez-grey-500">Launching with</p>
+			<p class="mb-6 font-ui text-sm uppercase tracking-wider text-ez-grey-500">Launching with</p>
 			<div class="flex flex-wrap items-center justify-center gap-8">
 				<div class="flex items-center gap-3 text-ez-grey-400">
-					<div class="h-px w-8 bg-ez-grey-700"></div>
-					<span class="font-ui text-lg font-medium">Skyrim SE</span>
-					<div class="h-px w-8 bg-ez-grey-700"></div>
+					<div class="h-px w-8 bg-ez-red-700"></div>
+					<span class="font-ui text-lg font-medium uppercase">Skyrim SE</span>
+					<div class="h-px w-8 bg-ez-red-700"></div>
 				</div>
 			</div>
 			<p class="mt-4 font-mono text-xs text-ez-grey-600">Fallout 4, New Vegas, and more coming soon</p>
+		</div>
+	</div>
+</section>
+
+<!-- Red CTA Section -->
+<section
+	class="relative overflow-hidden bg-ez-red-700 px-6 py-32 lg:px-8"
+	style="clip-path: polygon(0 10%, 100% 0, 100% 100%, 0 100%);"
+>
+	<!-- Background pattern -->
+	<div class="pointer-events-none absolute inset-0 opacity-10">
+		<div class="absolute right-0 top-0 h-full w-1/3 bg-linear-to-l from-white to-transparent"></div>
+		<div class="absolute left-1/4 top-1/4 size-64 rotate-45 border-8 border-white"></div>
+	</div>
+
+	<div class="relative mx-auto max-w-4xl text-center">
+		<h2 class="mb-6 font-display uppercase leading-[0.9] text-white">
+			<span class="block text-[clamp(3rem,10vw,8rem)]">Join the</span>
+			<span class="block text-[clamp(3rem,10vw,8rem)]">Community</span>
+		</h2>
+		<p class="mb-12 font-mono text-xl text-white/90">
+			Open source tools. Built by modders, for modders.
+		</p>
+		<div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+			<a
+				href="https://discord.gg/XJx4mYQZ"
+				class="group flex items-center gap-3 border-4 border-white bg-white px-10 py-5 font-ui text-xl uppercase tracking-wider text-ez-red-700 transition-all hover:bg-transparent hover:text-white hover:shadow-[0_0_40px_rgba(255,255,255,0.3)]"
+			>
+				<svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+				Join Discord
+			</a>
+			<a
+				href="https://github.com/ezmode-games"
+				class="group flex items-center gap-3 border-4 border-white bg-transparent px-10 py-5 font-ui text-xl uppercase tracking-wider text-white transition-all hover:bg-white hover:text-ez-red-700"
+			>
+				<svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+				GitHub
+			</a>
 		</div>
 	</div>
 </section>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,25 +7,25 @@ import Logo from './Logo.astro';
 	<div class="pointer-events-none fixed inset-0 z-50 opacity-[0.03]" style="background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.1) 2px, rgba(255,255,255,0.1) 4px);"></div>
 
 	<!-- Grid background -->
-	<div class="absolute inset-0 opacity-[0.04]" style="background-image: linear-gradient(rgba(254,154,0,0.3) 1px, transparent 1px), linear-gradient(90deg, rgba(254,154,0,0.3) 1px, transparent 1px); background-size: 60px 60px;"></div>
+	<div class="absolute inset-0 opacity-[0.04]" style="background-image: linear-gradient(rgba(144,2,2,0.3) 1px, transparent 1px), linear-gradient(90deg, rgba(144,2,2,0.3) 1px, transparent 1px); background-size: 60px 60px;"></div>
 
 	<!-- Accent glow -->
-	<div class="absolute -top-96 -right-96 h-200 w-200 rounded-full bg-ez-red-700/20 blur-3xl"></div>
+	<div class="absolute -top-96 -right-96 h-200 w-200 rounded-full bg-ez-red-700/30 blur-3xl"></div>
 	<div class="absolute -bottom-48 -left-48 h-150 w-150 rounded-full bg-ez-yellow-500/10 blur-3xl"></div>
 
 	<div class="relative mx-auto max-w-7xl px-6 py-24 lg:px-8 lg:py-32">
 		<!-- Top bar -->
-		<div class="mb-24 flex items-center justify-between border-b border-ez-grey-800 pb-6">
+		<div class="mb-24 flex items-center justify-between border-b-4 border-ez-grey-800 pb-6">
 			<a href="/" class="flex items-center gap-3">
 				<Logo class="size-10 text-white" />
-				<span class="font-display text-6xl font-semibold text-ez-yellow-500">games</span>
+				<span class="font-display text-6xl font-semibold text-white">games</span>
 			</a>
 			<div class="flex items-center gap-6">
-				<a href="https://github.com/ezmode-games" target="_blank" rel="noopener noreferrer" class="group flex items-center gap-2 font-mono text-sm text-ez-grey-400 transition-colors hover:text-ez-yellow-500">
+				<a href="https://github.com/ezmode-games" target="_blank" rel="noopener noreferrer" class="group flex items-center gap-2 font-mono text-sm text-ez-grey-400 transition-colors hover:text-white">
 					<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
 					<span class="hidden sm:inline">github</span>
 				</a>
-				<a href="https://discord.gg/XJx4mYQZ" target="_blank" rel="noopener noreferrer" class="group flex items-center gap-2 font-mono text-sm text-ez-grey-400 transition-colors hover:text-ez-yellow-500">
+				<a href="https://discord.gg/XJx4mYQZ" target="_blank" rel="noopener noreferrer" class="group flex items-center gap-2 font-mono text-sm text-ez-grey-400 transition-colors hover:text-white">
 					<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
 					<span class="hidden sm:inline">discord</span>
 				</a>
@@ -36,49 +36,56 @@ import Logo from './Logo.astro';
 		<div class="grid gap-16 lg:grid-cols-2 lg:gap-24">
 			<!-- Left: Text -->
 			<div class="flex flex-col justify-center">
-				<!-- Terminal prompt -->
-				<div class="mb-8 inline-flex items-center gap-2 font-mono text-sm text-ez-grey-500">
-					<span class="text-ez-green-500">$</span>
-					<span class="typing-animation">whoami</span>
+				<!-- Status badge -->
+				<div class="mb-8 inline-flex w-fit items-center gap-3 border-2 border-ez-green-500 bg-ez-green-500/20 px-6 py-3 backdrop-blur-sm">
+					<span class="size-3 animate-pulse rounded-full bg-ez-green-500"></span>
+					<span class="font-ui uppercase tracking-wider text-ez-green-500">CTD Live Now</span>
 				</div>
 
-				<h1 class="font-display text-5xl font-bold uppercase leading-none tracking-tight text-white sm:text-6xl lg:text-7xl">
-					We build<br />
-					<span class="text-ez-yellow-500">tools</span> for<br />
-					modders.
+				<h1 class="font-display text-5xl font-bold uppercase leading-[0.85] tracking-tight sm:text-6xl lg:text-7xl">
+					<span class="text-white">We build</span><br />
+					<span class="bg-linear-to-r from-ez-yellow-500 to-ez-red-700 bg-clip-text text-transparent">tools</span>
+					<span class="text-white"> for</span><br />
+					<span class="text-white">modders.</span>
 				</h1>
 
-				<p class="mt-8 max-w-lg font-mono text-base leading-relaxed text-ez-grey-400 sm:text-lg">
+				<p class="mt-8 max-w-lg border-l-4 border-ez-grey-500 pl-6 font-mono text-base leading-relaxed text-ez-grey-100 sm:text-lg">
 					Open source. Self-hostable. Free.<br />
 					No corporate overlords. No bullshit.
 				</p>
 
-				<!-- Status indicator -->
-				<div class="mt-12 flex items-center gap-4 border-l-2 border-ez-yellow-500 pl-4">
-					<div class="flex items-center gap-2">
-						<span class="relative flex h-2 w-2">
-							<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-ez-green-500 opacity-75"></span>
-							<span class="relative inline-flex h-2 w-2 rounded-full bg-ez-green-500"></span>
-						</span>
-						<span class="font-mono text-sm text-ez-grey-400">LIVE</span>
-					</div>
-					<span class="font-mono text-sm text-ez-grey-600">|</span>
-					<span class="font-mono text-sm text-ez-yellow-500">CTD Crash Reporter</span>
+				<!-- CTA buttons -->
+				<div class="mt-12 flex flex-wrap gap-4">
+					<a
+						href="#ctd"
+						class="group flex items-center gap-3 border-4 border-ez-yellow-500 bg-ez-yellow-500 px-10 py-5 font-ui text-xl uppercase tracking-wider text-ez-grey-900 transition-all hover:border-ez-yellow-400 hover:bg-ez-yellow-400"
+					>
+						Try CTD
+						<svg class="h-6 w-6 transition-transform group-hover:translate-x-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+						</svg>
+					</a>
+					<a
+						href="https://github.com/ezmode-games"
+						class="group flex items-center gap-3 border-4 border-ez-red-700 bg-transparent px-10 py-5 font-ui text-xl uppercase tracking-wider text-ez-red-500 transition-all hover:bg-ez-red-700 hover:text-white"
+					>
+						<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+						View Source
+					</a>
 				</div>
 			</div>
 
 			<!-- Right: Visual element -->
 			<div class="relative flex items-center justify-center">
-				<!-- Decorative frame -->
-				<div class="absolute inset-0 border border-ez-grey-800"></div>
-				<div class="absolute -inset-2 border border-ez-grey-800/50"></div>
-				<div class="absolute -inset-4 border border-ez-grey-800/25"></div>
+				<!-- Decorative frame with bold borders -->
+				<div class="absolute inset-0 border-4 border-ez-grey-800"></div>
+				<div class="absolute -inset-3 border-2 border-ez-grey-800/50"></div>
 
-				<!-- Corner accents -->
-				<div class="absolute -left-1 -top-1 h-4 w-4 border-l-2 border-t-2 border-ez-yellow-500"></div>
-				<div class="absolute -right-1 -top-1 h-4 w-4 border-r-2 border-t-2 border-ez-yellow-500"></div>
-				<div class="absolute -bottom-1 -left-1 h-4 w-4 border-b-2 border-l-2 border-ez-yellow-500"></div>
-				<div class="absolute -bottom-1 -right-1 h-4 w-4 border-b-2 border-r-2 border-ez-yellow-500"></div>
+				<!-- Corner accents - now red for brand hierarchy -->
+				<div class="absolute -left-1.5 -top-1.5 h-6 w-6 border-l-4 border-t-4 border-ez-red-700"></div>
+				<div class="absolute -right-1.5 -top-1.5 h-6 w-6 border-r-4 border-t-4 border-ez-red-700"></div>
+				<div class="absolute -bottom-1.5 -left-1.5 h-6 w-6 border-b-4 border-l-4 border-ez-red-700"></div>
+				<div class="absolute -bottom-1.5 -right-1.5 h-6 w-6 border-b-4 border-r-4 border-ez-red-700"></div>
 
 				<!-- Terminal window -->
 				<div class="relative w-full bg-ez-grey-900/80 p-6 backdrop-blur sm:p-8">
@@ -95,7 +102,7 @@ import Logo from './Logo.astro';
 						<div><span class="text-ez-grey-600">[INFO]</span> Reading load order: 247 plugins</div>
 						<div><span class="text-ez-grey-600">[INFO]</span> Game: Skyrim SE v1.6.1170</div>
 						<div><span class="text-ez-yellow-500">[CTD]</span> Report generated: #a7f3d2</div>
-						<div><span class="text-ez-green-500">[OK]</span> Share with creator: <span class="text-ez-yellow-500 underline">ctd.ezmode.games/a7f3d2</span></div>
+						<div><span class="text-ez-green-500">[OK]</span> Share with creator: <span class="text-white underline">ctd.ezmode.games/a7f3d2</span></div>
 					</div>
 				</div>
 			</div>
@@ -103,7 +110,7 @@ import Logo from './Logo.astro';
 
 		<!-- Scroll indicator -->
 		<div class="mt-24 flex justify-center lg:mt-32">
-			<a href="#ctd" class="group flex flex-col items-center gap-2 text-ez-grey-500 transition-colors hover:text-ez-yellow-500">
+			<a href="#ctd" class="group flex flex-col items-center gap-2 text-ez-grey-500 transition-colors hover:text-white">
 				<span class="font-mono text-xs uppercase tracking-widest">Scroll</span>
 				<svg class="h-6 w-6 animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
@@ -112,22 +119,3 @@ import Logo from './Logo.astro';
 		</div>
 	</div>
 </section>
-
-<style>
-	.typing-animation {
-		overflow: hidden;
-		border-right: 2px solid var(--color-ez-yellow-500);
-		white-space: nowrap;
-		animation: typing 1s steps(6, end), blink-caret 0.75s step-end infinite;
-	}
-
-	@keyframes typing {
-		from { width: 0 }
-		to { width: 100% }
-	}
-
-	@keyframes blink-caret {
-		from, to { border-color: transparent }
-		50% { border-color: var(--color-ez-yellow-500) }
-	}
-</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,7 +25,7 @@ const { title = 'EZMode Games', description = 'EZMode Games - Gaming made easy' 
 			rel="stylesheet"
 		/>
 	</head>
-	<body class="min-h-screen font-sans antialiased">
+	<body class="min-h-screen overflow-x-hidden font-sans antialiased">
 		<div class="flex min-h-screen flex-col">
 			<slot />
 		</div>


### PR DESCRIPTION
## Summary
- Update color hierarchy to match platform: red as primary brand color, yellow as accent
- Add gradient text (yellow→red) and 4px brutal borders throughout
- Add red CTA section with clip-path diagonal matching platform's CtaSection
- Fix horizontal scroll issue with overflow-x-hidden
- Configure Playwright to only run webkit on CI (missing local deps)

## Test plan
- [x] Unit tests pass (4/4)
- [x] E2E tests pass on chromium and firefox (34/34)
- [x] Build succeeds
- [x] Visual check: brand colors now match platform hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)