### PR TITLE
docs: add drizzle-ledger documentation page

### DIFF
--- a/src/pages/oss.astro
+++ b/src/pages/oss.astro
@@ -49,6 +49,17 @@ const projects = [
     color: 'yellow',
   },
   {
+    name: 'Drizzle Ledger',
+    tagline: 'Soft-Delete + Audit + GDPR',
+    description:
+      'Soft-delete, audit trail, and GDPR compliance for Drizzle ORM. Adds deleted_at columns, automatic delete-to-update rewriting, full audit trail with AsyncLocalStorage context, and GDPR purge. SQLite, PostgreSQL, MySQL.',
+    license: 'MIT',
+    tech: ['TypeScript', 'Drizzle ORM'],
+    github: 'https://github.com/ezmode-games/drizzle-ledger',
+    website: '/oss/drizzle-ledger',
+    color: 'green',
+  },
+  {
     name: 'Smuggler',
     tagline: 'D1 Data Migration',
     description:

--- a/src/pages/oss/drizzle-ledger.astro
+++ b/src/pages/oss/drizzle-ledger.astro
@@ -1,0 +1,554 @@
+---
+import FooterSimple from '../../components/FooterSimple.astro';
+import Logo from '../../components/Logo.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const kw = 'text-ez-yellow-500';
+const str = 'text-ez-green-500';
+const num = 'text-ez-red-400';
+const cmt = 'text-ez-grey-500';
+
+const codeSoftDeleteColumns = `<span class="${kw}">import</span> { sqliteTable, text } <span class="${kw}">from</span> <span class="${str}">"drizzle-orm/sqlite-core"</span>;
+<span class="${kw}">import</span> { softDeleteColumns } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/soft-delete/sqlite"</span>;
+
+<span class="${kw}">export const</span> users = sqliteTable(<span class="${str}">"users"</span>, {
+  id: text(<span class="${str}">"id"</span>).primaryKey(),
+  name: text(<span class="${str}">"name"</span>),
+  email: text(<span class="${str}">"email"</span>).unique(),
+  ...softDeleteColumns,
+});
+
+<span class="${cmt}">// Adds: deleted_at (timestamp), deleted_by (text)</span>`;
+
+const codeFilters = `<span class="${kw}">import</span> { notDeleted, onlyDeleted } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/soft-delete"</span>;
+
+<span class="${cmt}">// Active records only</span>
+<span class="${kw}">const</span> active = <span class="${kw}">await</span> db
+  .select()
+  .from(users)
+  .where(notDeleted(users));
+
+<span class="${cmt}">// Trash view / admin dashboard</span>
+<span class="${kw}">const</span> deleted = <span class="${kw}">await</span> db
+  .select()
+  .from(users)
+  .where(onlyDeleted(users));`;
+
+const codeAuditedDb = `<span class="${kw}">import</span> { createAuditedDb } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/db"</span>;
+
+<span class="${kw}">const</span> db = createAuditedDb(drizzle(env.DB), {
+  hardDeleteTables: [<span class="${str}">"session"</span>, <span class="${str}">"verification"</span>],
+});
+
+<span class="${cmt}">// This becomes a soft-delete (users has deleted_at)</span>
+<span class="${kw}">await</span> db.delete(users).where(eq(users.id, userId));
+
+<span class="${cmt}">// This is a real delete (session is in hardDeleteTables)</span>
+<span class="${kw}">await</span> db.delete(session).where(eq(session.id, sessionId));`;
+
+const codeContext = `<span class="${kw}">import</span> { createLedgerContext, runWithLedgerContext } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/context"</span>;
+
+app.use(<span class="${kw}">async</span> (c, next) =&gt; {
+  <span class="${kw}">const</span> context = createLedgerContext({
+    userId: c.get(<span class="${str}">"user"</span>)?.id,
+    ip: c.req.header(<span class="${str}">"x-forwarded-for"</span>),
+    userAgent: c.req.header(<span class="${str}">"user-agent"</span>),
+    endpoint: <span class="${str}">\`\${c.req.method} \${c.req.path}\`</span>,
+  });
+  <span class="${kw}">return</span> runWithLedgerContext(context, next);
+});`;
+
+const codeAuditManual = `<span class="${kw}">import</span> { logInsert, logUpdate } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/audit"</span>;
+
+<span class="${cmt}">// After inserting</span>
+<span class="${kw}">const</span> [user] = <span class="${kw}">await</span> db.insert(users).values(data).returning();
+<span class="${kw}">await</span> logInsert(db, auditLog, <span class="${str}">"users"</span>, user.id, user);
+
+<span class="${cmt}">// After updating</span>
+<span class="${kw}">const</span> [oldUser] = <span class="${kw}">await</span> db.select().from(users).where(eq(users.id, id));
+<span class="${kw}">const</span> [newUser] = <span class="${kw}">await</span> db.update(users).set(changes)
+  .where(eq(users.id, id)).returning();
+<span class="${kw}">await</span> logUpdate(db, auditLog, <span class="${str}">"users"</span>, id, oldUser, newUser);`;
+
+const codeAuditLogger = `<span class="${kw}">import</span> { AuditLogger } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/logger"</span>;
+
+<span class="${kw}">const</span> logger = <span class="${kw}">new</span> AuditLogger(
+  <span class="${kw}">async</span> (entry) =&gt; {
+    <span class="${kw}">await</span> db.insert(auditLog).values({ ...entry, id: uuidv7() });
+  },
+  { excludeTables: [<span class="${str}">"audit_log"</span>, <span class="${str}">"session"</span>] }
+);
+
+<span class="${kw}">const</span> db = drizzle(env.DB, { logger });`;
+
+const codeGdpr = `<span class="${kw}">import</span> { purgeUserData, isUserDataPurged } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/gdpr"</span>;
+
+<span class="${kw}">const</span> result = <span class="${kw}">await</span> purgeUserData(db, auditLog, <span class="${str}">"user-123"</span>, {
+  piiFields: [<span class="${str}">"email"</span>, <span class="${str}">"name"</span>, <span class="${str}">"phone"</span>, <span class="${str}">"address"</span>, <span class="${str}">"ip"</span>],
+  anonymizedUserId: <span class="${str}">"PURGED_USER"</span>,
+});
+<span class="${cmt}">// { entriesAnonymized: 47, tablesProcessed: ["users", "accounts"] }</span>
+
+<span class="${cmt}">// Idempotency check</span>
+<span class="${kw}">const</span> purged = <span class="${kw}">await</span> isUserDataPurged(db, auditLog, <span class="${str}">"user-123"</span>);`;
+
+const codeBetterAuth = `<span class="${kw}">import</span> { ledgerPlugin, createSoftDeleteCallback } <span class="${kw}">from</span> <span class="${str}">"@ezmode-games/drizzle-ledger/better-auth"</span>;
+
+<span class="${kw}">export const</span> auth = betterAuth({
+  user: {
+    deleteUser: {
+      enabled: <span class="${num}">true</span>,
+      beforeDelete: createSoftDeleteCallback({
+        db,
+        userTable: users,
+        whereUserId: (userId) =&gt; eq(users.id, userId),
+        writeAuditEntry: <span class="${kw}">async</span> (entry) =&gt; {
+          <span class="${kw}">await</span> db.insert(auditLog).values({ ...entry, id: uuidv7() });
+        },
+      }),
+    },
+  },
+  plugins: [
+    ledgerPlugin({
+      writeAuditEntry: <span class="${kw}">async</span> (entry) =&gt; {
+        <span class="${kw}">await</span> db.insert(auditLog).values({ ...entry, id: uuidv7() });
+      },
+      auditTables: [<span class="${str}">"user"</span>, <span class="${str}">"account"</span>],
+    }),
+  ],
+});`;
+---
+
+<BaseLayout
+	title="Drizzle Ledger - ezmode.games"
+	description="Soft-delete, audit trail, and GDPR compliance for Drizzle ORM. SQLite, PostgreSQL, MySQL. Stop rewriting the same infrastructure for every project."
+>
+	<div class="min-h-screen bg-ez-grey-950">
+		<!-- Header -->
+		<header class="border-b border-ez-grey-800">
+			<div class="mx-auto max-w-4xl px-6 py-6">
+				<div class="flex items-center justify-between">
+					<a href="/" class="flex items-center gap-3">
+						<Logo class="size-10 text-white" />
+						<span class="font-display text-6xl font-semibold text-ez-yellow-500">games</span>
+					</a>
+					<a
+						href="/oss"
+						class="font-mono text-sm text-ez-grey-500 transition-colors hover:text-ez-green-500"
+					>
+						&larr; All Projects
+					</a>
+				</div>
+			</div>
+		</header>
+
+		<!-- Content -->
+		<main class="mx-auto max-w-4xl px-6 py-16">
+			<!-- Hero -->
+			<div class="mb-16">
+				<div class="mb-4 flex flex-wrap items-center gap-4">
+					<h1 class="font-display text-4xl font-bold uppercase text-white">Drizzle Ledger</h1>
+					<span class="inline-flex items-center border-2 border-ez-grey-700 bg-ez-grey-800 px-3 py-1 font-mono text-xs text-ez-grey-400">
+						MIT
+					</span>
+				</div>
+				<p class="mb-6 font-ui text-sm uppercase tracking-wider text-ez-green-500">
+					Soft-Delete + Audit Trail + GDPR
+				</p>
+				<p class="mb-8 max-w-2xl font-mono text-sm leading-relaxed text-ez-grey-300">
+					Stop rewriting soft-delete for every project. Adds soft-delete columns, automatic
+					delete-to-update rewriting, full audit trail with AsyncLocalStorage context, and GDPR
+					purge to any Drizzle ORM project. SQLite, PostgreSQL, MySQL.
+				</p>
+
+				<!-- Install -->
+				<div class="flex flex-wrap gap-3">
+					<div class="border-2 border-ez-green-500 bg-ez-green-500/10 px-4 py-2">
+						<code class="font-mono text-sm text-ez-green-500">pnpm add @ezmode-games/drizzle-ledger</code>
+					</div>
+					<a
+						href="https://github.com/ezmode-games/drizzle-ledger"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-2 border-2 border-ez-grey-600 bg-transparent px-4 py-2 font-ui text-sm uppercase tracking-wider text-ez-grey-400 transition-all hover:border-ez-grey-500 hover:bg-ez-grey-800 hover:text-white"
+					>
+						<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+						Source
+					</a>
+					<a
+						href="https://www.npmjs.com/package/@ezmode-games/drizzle-ledger"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-2 border-2 border-ez-grey-600 bg-transparent px-4 py-2 font-ui text-sm uppercase tracking-wider text-ez-grey-400 transition-all hover:border-ez-grey-500 hover:bg-ez-grey-800 hover:text-white"
+					>
+						npm
+					</a>
+				</div>
+			</div>
+
+			<!-- Architecture -->
+			<div class="mb-16 border-4 border-ez-green-500 bg-ez-green-500/10 p-6 sm:p-8">
+				<h2 class="mb-4 font-ui text-sm font-bold uppercase tracking-wider text-ez-green-500">Architecture</h2>
+				<div class="flex flex-wrap items-center gap-3 font-mono text-sm">
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-3 py-1 text-white">Drizzle Table</span>
+					<span class="text-ez-green-500">&rarr;</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-3 py-1 text-white">...softDeleteColumns</span>
+					<span class="text-ez-green-500">&rarr;</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-3 py-1 text-white">createAuditedDb()</span>
+					<span class="text-ez-green-500">&rarr;</span>
+					<div class="flex flex-col gap-2">
+						<span class="border-2 border-ez-green-500 bg-ez-grey-900 px-3 py-1 text-ez-green-500">db.delete() &rarr; soft-delete</span>
+						<span class="border-2 border-ez-green-500 bg-ez-grey-900 px-3 py-1 text-ez-green-500">audit trail &rarr; who/what/when</span>
+						<span class="border-2 border-ez-green-500 bg-ez-grey-900 px-3 py-1 text-ez-green-500">purgeUserData() &rarr; GDPR</span>
+					</div>
+				</div>
+			</div>
+
+			<!-- Table of Contents -->
+			<nav class="mb-16 border border-ez-grey-800 bg-ez-grey-900 p-6">
+				<h2 class="mb-4 font-ui text-sm font-bold uppercase tracking-wider text-ez-green-500">Contents</h2>
+				<ul class="space-y-2 font-mono text-sm">
+					<li><a href="#soft-delete" class="text-ez-grey-400 hover:text-ez-green-500">1. Soft-Delete Columns</a></li>
+					<li><a href="#automatic" class="text-ez-grey-400 hover:text-ez-green-500">2. Automatic Soft-Delete</a></li>
+					<li><a href="#audit" class="text-ez-grey-400 hover:text-ez-green-500">3. Audit Trail</a></li>
+					<li><a href="#gdpr" class="text-ez-grey-400 hover:text-ez-green-500">4. GDPR Purge</a></li>
+					<li><a href="#better-auth" class="text-ez-grey-400 hover:text-ez-green-500">5. Better Auth Integration</a></li>
+					<li><a href="#exports" class="text-ez-grey-400 hover:text-ez-green-500">6. Subpath Exports</a></li>
+				</ul>
+			</nav>
+
+			<!-- 1. Soft-Delete Columns -->
+			<section id="soft-delete" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					1. Soft-Delete Columns
+				</h2>
+
+				<div class="space-y-8 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<div>
+						<p class="text-ez-grey-400">
+							Spread <code class="text-white">softDeleteColumns</code> into any table definition.
+							Adds <code class="text-white">deleted_at</code> (timestamp) and <code class="text-white">deleted_by</code> (text).
+							Dialect-specific types: integer timestamp for SQLite, <code class="text-white">timestamptz</code> for Postgres,
+							<code class="text-white">timestamp</code> for MySQL.
+						</p>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">Add to a Table</h3>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeSoftDeleteColumns} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">Query Helpers</h3>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeFilters} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">Dialect Imports</h3>
+						<div class="grid gap-4 sm:grid-cols-3">
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">soft-delete/sqlite</code>
+								<div class="mt-1 text-ez-grey-500">integer timestamp</div>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">soft-delete/pg</code>
+								<div class="mt-1 text-ez-grey-500">timestamptz</div>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">soft-delete/mysql</code>
+								<div class="mt-1 text-ez-grey-500">timestamp</div>
+							</div>
+						</div>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">Also Available</h3>
+						<div class="grid gap-4 sm:grid-cols-2">
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">softDeleteTimestamp</code>
+								<span class="ml-2 text-ez-grey-500">deleted_at only, no deleted_by</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">softDeleteValues(userId?)</code>
+								<span class="ml-2 text-ez-grey-500">for manual .set() calls</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">restoreValues()</code>
+								<span class="ml-2 text-ez-grey-500">undo a soft-delete</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-white">isSoftDeleted(record)</code>
+								<span class="ml-2 text-ez-grey-500">runtime check</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- 2. Automatic Soft-Delete -->
+			<section id="automatic" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					2. Automatic Soft-Delete
+				</h2>
+
+				<div class="space-y-8 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<div>
+						<p class="text-ez-grey-400">
+							<code class="text-white">createAuditedDb(db)</code> intercepts <code class="text-white">db.delete()</code>
+							and rewrites it to a soft-delete UPDATE for any table with a <code class="text-white">deleted_at</code> column.
+							Tables without it pass through to a normal hard delete. The right thing happens by default.
+						</p>
+					</div>
+
+					<div>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeAuditedDb} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">How It Works</h3>
+						<ul class="ml-4 list-inside list-disc space-y-2 text-ez-grey-400">
+							<li>Table has <code class="text-white">deleted_at</code>? <span class="text-white">Soft-delete</span> (UPDATE with timestamp)</li>
+							<li>Table in <code class="text-white">hardDeleteTables</code>? <span class="text-white">Hard delete</span> (normal DELETE)</li>
+							<li>No <code class="text-white">deleted_at</code> column? <span class="text-white">Hard delete</span> (pass-through)</li>
+							<li><code class="text-white">.where()</code>, <code class="text-white">.returning()</code>, <code class="text-white">.execute()</code> all work as normal</li>
+						</ul>
+					</div>
+				</div>
+			</section>
+
+			<!-- 3. Audit Trail -->
+			<section id="audit" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					3. Audit Trail
+				</h2>
+
+				<div class="space-y-8 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<div>
+						<p class="text-ez-grey-400">
+							Every mutation records <span class="text-white">who</span> changed <span class="text-white">what</span> record
+							in <span class="text-white">which</span> table, <span class="text-white">when</span>,
+							from <span class="text-white">where</span> (IP, user agent, endpoint), with <span class="text-white">before</span>
+							and <span class="text-white">after</span> state as JSON snapshots.
+						</p>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">Context Propagation</h3>
+						<p class="mb-3 text-ez-grey-400">
+							Set context once in middleware via AsyncLocalStorage. Every audit entry downstream automatically
+							inherits userId, IP, user agent, endpoint, and request ID. No prop drilling.
+						</p>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeContext} /></pre>
+						<p class="mt-3 text-ez-grey-500">
+							Works in Node.js, Bun, Deno, and Cloudflare Workers.
+						</p>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">Manual Logging</h3>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeAuditManual} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">Automatic Logging</h3>
+						<p class="mb-3 text-ez-grey-400">
+							Plug into Drizzle's logger interface. Intercepts INSERT/UPDATE/DELETE queries automatically.
+						</p>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeAuditLogger} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">SOC 2 Coverage</h3>
+						<div class="grid gap-4 sm:grid-cols-2">
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">CC6.1</code>
+								<span class="ml-2 text-ez-grey-400">Logical access - userId on every entry</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">CC7.2</code>
+								<span class="ml-2 text-ez-grey-400">System monitoring - before/after snapshots</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">CC8.1</code>
+								<span class="ml-2 text-ez-grey-400">Change management - timestamped, typed actions</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">Source</code>
+								<span class="ml-2 text-ez-grey-400">IP, user agent, endpoint, request ID</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- 4. GDPR Purge -->
+			<section id="gdpr" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					4. GDPR Purge
+				</h2>
+
+				<div class="space-y-8 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<div>
+						<p class="text-ez-grey-400">
+							A user exercises their right to erasure (Article 17). You need to remove their PII from the audit trail
+							without destroying the trail itself. <code class="text-white">purgeUserData</code> anonymizes their entries.
+							The structure stays intact. The PII goes away.
+						</p>
+					</div>
+
+					<div>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeGdpr} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-ez-green-500">What It Does</h3>
+						<ul class="ml-4 list-inside list-disc space-y-2 text-ez-grey-400">
+							<li>Finds all audit entries for the user (by userId and recordId)</li>
+							<li>Recursively strips configured PII fields from JSON snapshots</li>
+							<li>Replaces <code class="text-white">userId</code> with <code class="text-white">PURGED_USER</code> on user's own entries</li>
+							<li>Nullifies IP and userAgent on user's own entries</li>
+							<li>Preserves admin entries untouched - admin userId/IP stays</li>
+							<li>Idempotent - safe to run multiple times</li>
+						</ul>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">GDPR Coverage</h3>
+						<div class="grid gap-4 sm:grid-cols-2">
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">Art. 5(2)</code>
+								<span class="ml-2 text-ez-grey-400">Accountability - full audit trail</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">Art. 17</code>
+								<span class="ml-2 text-ez-grey-400">Right to erasure - purgeUserData</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">Art. 30</code>
+								<span class="ml-2 text-ez-grey-400">Records of processing - per-record history</span>
+							</div>
+							<div class="border border-ez-grey-800 bg-ez-grey-900 p-4">
+								<code class="text-ez-green-500">Art. 33</code>
+								<span class="ml-2 text-ez-grey-400">Breach response - scope determination</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- 5. Better Auth Integration -->
+			<section id="better-auth" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					5. Better Auth Integration
+				</h2>
+
+				<div class="space-y-8 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<div>
+						<p class="text-ez-grey-400">
+							Hooks into Better Auth's <code class="text-white">databaseHooks</code> to automatically log
+							user/account operations. The soft-delete callback intercepts <code class="text-white">deleteUser</code>
+							to perform soft-delete instead of hard delete.
+						</p>
+					</div>
+
+					<div>
+						<pre class="border border-ez-grey-800 bg-ez-grey-900 p-4"><code class="text-ez-grey-300" set:html={codeBetterAuth} /></pre>
+					</div>
+
+					<div>
+						<h3 class="mb-3 font-ui text-base font-bold text-white">Detection</h3>
+						<p class="text-ez-grey-400">
+							<code class="text-white">createSoftDeleteCallback</code> performs the soft-delete, logs an audit entry,
+							then throws to prevent the hard delete. Use <code class="text-white">isSoftDeletePerformed(error)</code>
+							to detect success in your client code.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<!-- 6. Subpath Exports -->
+			<section id="exports" class="mb-16">
+				<h2 class="mb-6 border-b border-ez-grey-800 pb-4 font-display text-2xl font-bold uppercase text-white">
+					6. Subpath Exports
+				</h2>
+
+				<div class="space-y-4 font-mono text-sm leading-relaxed text-ez-grey-300">
+					<p class="text-ez-grey-400">Every subpath is independently tree-shakeable. Import only what you need.</p>
+
+					<div class="grid gap-3">
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">soft-delete/sqlite</code>
+							<span class="text-ez-grey-500">SQLite columns</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">soft-delete/pg</code>
+							<span class="text-ez-grey-500">Postgres columns</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">soft-delete/mysql</code>
+							<span class="text-ez-grey-500">MySQL columns</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">soft-delete</code>
+							<span class="text-ez-grey-500">Dialect-agnostic helpers</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">schema/sqlite</code>
+							<span class="text-ez-grey-500">SQLite audit table</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">schema/pg</code>
+							<span class="text-ez-grey-500">Postgres audit table</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">schema/mysql</code>
+							<span class="text-ez-grey-500">MySQL audit table</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">audit</code>
+							<span class="text-ez-grey-500">Manual audit functions</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">context</code>
+							<span class="text-ez-grey-500">AsyncLocalStorage context</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">db</code>
+							<span class="text-ez-grey-500">Automatic soft-delete wrapper</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">gdpr</code>
+							<span class="text-ez-grey-500">GDPR purge</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">logger</code>
+							<span class="text-ez-grey-500">Drizzle Logger with audit</span>
+						</div>
+						<div class="flex items-baseline gap-4 border border-ez-grey-800 bg-ez-grey-900 p-4">
+							<code class="shrink-0 text-white">better-auth</code>
+							<span class="text-ez-grey-500">Better Auth plugin</span>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Tech stack -->
+			<section class="mb-16 border border-ez-grey-800 bg-ez-grey-900 p-6">
+				<h2 class="mb-4 font-ui text-sm font-bold uppercase tracking-wider text-ez-green-500">Stack</h2>
+				<div class="flex flex-wrap gap-2">
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">TypeScript</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">Drizzle ORM</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">SQLite</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">PostgreSQL</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">MySQL</span>
+					<span class="border-2 border-ez-grey-700 bg-ez-grey-900 px-2 py-1 font-mono text-xs text-ez-grey-500">AsyncLocalStorage</span>
+				</div>
+				<p class="mt-4 font-mono text-xs text-ez-grey-500">
+					MIT Licensed. <a href="https://github.com/ezmode-games/drizzle-ledger" target="_blank" rel="noopener noreferrer" class="text-ez-green-500 hover:underline">View source on GitHub.</a>
+				</p>
+			</section>
+		</main>
+	</div>
+
+	<FooterSimple />
+</BaseLayout>

--- a/test/pages/index.e2e.ts
+++ b/test/pages/index.e2e.ts
@@ -252,13 +252,14 @@ test.describe('Open Source Page', () => {
     await expect(page).toHaveTitle(/Open Source/i);
   });
 
-  test('should display all five projects', async ({ page }) => {
+  test('should display all six projects', async ({ page }) => {
     await page.goto('/oss');
 
     await expect(page.getByRole('heading', { name: 'CTD' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Ferritest' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Kelex' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Rafters' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Drizzle Ledger' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Smuggler' })).toBeVisible();
   });
 
@@ -269,6 +270,7 @@ test.describe('Open Source Page', () => {
     await expect(page.getByText('Memory Stress Test')).toBeVisible();
     await expect(page.getByText('Form Generation')).toBeVisible();
     await expect(page.getByText('Design Intelligence')).toBeVisible();
+    await expect(page.getByText('Soft-Delete + Audit + GDPR')).toBeVisible();
     await expect(page.getByText('D1 Data Migration')).toBeVisible();
   });
 
@@ -280,7 +282,7 @@ test.describe('Open Source Page', () => {
     // CTD is AGPL-3.0, others are MIT
     await expect(main.getByText('AGPL-3.0')).toBeVisible();
     const mitBadges = main.getByText('MIT', { exact: true });
-    expect(await mitBadges.count()).toBe(4);
+    expect(await mitBadges.count()).toBe(5);
   });
 
   test('should have GitHub source links for all projects', async ({ page }) => {
@@ -288,7 +290,7 @@ test.describe('Open Source Page', () => {
 
     const main = page.locator('main');
     const sourceLinks = main.getByRole('link', { name: /^Source$/i });
-    expect(await sourceLinks.count()).toBe(5);
+    expect(await sourceLinks.count()).toBe(6);
 
     // All source links should point to GitHub
     for (const link of await sourceLinks.all()) {
@@ -300,9 +302,9 @@ test.describe('Open Source Page', () => {
   test('should have website links where applicable', async ({ page }) => {
     await page.goto('/oss');
 
-    // CTD, Kelex, and Rafters have websites
+    // CTD, Kelex, Rafters, and Drizzle Ledger have websites
     const websiteLinks = page.getByRole('link', { name: /Website/i });
-    expect(await websiteLinks.count()).toBe(3);
+    expect(await websiteLinks.count()).toBe(4);
 
     // Check CTD website
     await expect(page.getByRole('link', { name: /Website/i }).first()).toHaveAttribute(


### PR DESCRIPTION
## Summary
- Add full documentation page at `/oss/drizzle-ledger` covering soft-delete columns, automatic delete-to-update rewriting, audit trail, GDPR purge, Better Auth integration, and subpath exports
- Add drizzle-ledger card to the OSS hub page (`/oss`) with green accent color
- Update e2e tests for new project counts (5->6 projects, 4->5 MIT badges, 5->6 source links, 3->4 website links)

## Test plan
- [x] Lint passes (biome check)
- [x] Typecheck passes (astro check, 0 errors)
- [x] Build passes (5 pages built)
- [x] Unit tests pass (15/15)
- [x] E2E tests pass (68/68, chromium + firefox)

Generated with [Claude Code](https://claude.com/claude-code)